### PR TITLE
Patch to limit the consumer session retry

### DIFF
--- a/kafka_handler.go
+++ b/kafka_handler.go
@@ -14,15 +14,18 @@ func newConsumerHandler(handlers map[string]TopicHandler, fallback map[string]To
 
 type consumerHandler struct {
 	ready               chan bool
+	retryCount          int8
 	handlers, fallbacks map[string]TopicHandler
 }
 
 func (ch *consumerHandler) Setup(sarama.ConsumerGroupSession) error {
+	ch.retryCount = 0
 	close(ch.ready)
 	return nil
 }
 
 func (ch *consumerHandler) Cleanup(sarama.ConsumerGroupSession) error {
+	ch.retryCount = 0
 	return nil
 }
 

--- a/kafka_producer.go
+++ b/kafka_producer.go
@@ -96,6 +96,7 @@ type kafkaProducerParam struct {
 
 	// [Optional]
 	// kafka cluster version. eg - "2.2.1" default - "2.3.0"
+	// supports versions from "0.8.x" to "2.3.x"
 	Version string
 
 	// [Optional]


### PR DESCRIPTION
1) while starting a consumer session, it can cause a repeated error,
patch restrict retries in such cases to 5 attempt with linear backoff
2) A successful setup and clean up will reset the retry counter
3) version support comments